### PR TITLE
fix: remove default postgres tag

### DIFF
--- a/charts/cd-indicators/values.yaml
+++ b/charts/cd-indicators/values.yaml
@@ -28,9 +28,6 @@ postgresql:
   postgresqlDatabase: indicators
   postgresqlUsername: postgres
   postgresqlPassword: password
-  existingSecret:
-  image:
-    tag: 13.1.0-debian-10-r38
 
 # this is the label defined in Grafana sidecar dashboards/datasources loader
 # used to retrieve all configmaps which contains Grafana dashboards/datasources


### PR DESCRIPTION
because it gets set to the cd-indicators version at release time
we'll set this in the versionstream values instead