### PR TITLE
chore: remove upload-binaries step

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -33,8 +33,6 @@ spec:
           resources: {}
         - name: release-chart
           resources: {}
-        - name: upload-binaries
-          resources: {}
         - name: promote-release
           resources: {}
   serviceAccountName: tekton-bot


### PR DESCRIPTION
I don't think the binaries are needed for cd-indicators. The step also fails and would be slow if it did work.