### PR TITLE
fix: compatibility with Grafana 12.2 and later

### DIFF
--- a/charts/cd-indicators/templates/secret.yaml
+++ b/charts/cd-indicators/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- $jsonData := dict "database" .Values.postgresql.postgresqlDatabase }}
+{{ $_ := merge $jsonData .Values.grafana.datasources.postgres.settings }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,4 +13,4 @@ stringData:
   postgresql-username: {{ .Values.postgresql.postgresqlUsername }}
   postgresql-password: {{ .Values.postgresql.postgresqlPassword }}
   grafana-datasource-postgresql-json-data: |
-    {{ toJson .Values.grafana.datasources.postgres.settings }}
+    {{ toJson $jsonData }}

--- a/charts/cd-indicators/templates/secret_grafana_datasource.yaml
+++ b/charts/cd-indicators/templates/secret_grafana_datasource.yaml
@@ -1,3 +1,5 @@
+{{- $jsonData := dict "database" .Values.postgresql.postgresqlDatabase }}
+{{ $_ := merge $jsonData .Values.grafana.datasources.postgres.settings }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,4 +19,4 @@ stringData:
         user: {{ .Values.postgresql.postgresqlUsername }}
         secureJsonData:
           password: {{ .Values.postgresql.postgresqlPassword | quote }}
-        jsonData: {{- toYaml .Values.grafana.datasources.postgres.settings | nindent 10 }}
+        jsonData: {{- toYaml $jsonData | nindent 10 }}


### PR DESCRIPTION
Grafana 12.2 and onwards requires database in the jsonData of a PostgreSQL data source

grafana/grafana#108443 since the error was reported in grafana/grafana#112418
